### PR TITLE
Remove typealias as AsyncImage

### DIFF
--- a/Sources/SBPAsyncImage/AsyncImage.swift
+++ b/Sources/SBPAsyncImage/AsyncImage.swift
@@ -1,5 +1,0 @@
-@available(iOS, deprecated: 15.0, renamed: "SwiftUI.AsyncImage")
-@available(macOS, deprecated: 12.0, renamed: "SwiftUI.AsyncImage")
-@available(tvOS, deprecated: 15.0, renamed: "SwiftUI.AsyncImage")
-@available(watchOS, deprecated: 8.0, renamed: "SwiftUI.AsyncImage")
-public typealias AsyncImage = BackportAsyncImage


### PR DESCRIPTION
Remove typealias as AsyncImage because `SwiftUI.AsyncImage` has stable and is widely used.