### PR TITLE
Update .gitignore for Swift 5.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 /*.xcodeproj
 xcuserdata/
 DerivedData/
+.swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc


### PR DESCRIPTION
```
$swift --version
swift-driver version: 1.45.2 Apple Swift version 5.6.1 (swiftlang-5.6.0.323.66 clang-1316.0.20.12)
Target: arm64-apple-macosx12.0

$xcodebuild -version 
Xcode 13.4
Build version 13F17a
```

## Refs

```
* https://github.com/apple/swift-package-manager/pull/2674
* https://github.com/apple/swift-package-manager/pull/3511
* https://github.com/apple/swift-package-manager/pull/3468
```